### PR TITLE
Change ConvertFrom-Toml pipe input behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for PSToml
 
+## v0.2.0 - 2023-05-23
+
++ Changed piping behaviour of `ConvertFrom-Toml` to build the final TOML string for each input rather than try and convert each string input as individual TOML entries
+  + This copies the behaviour of `ConvertFrom-Json` and makes `Get-Content $path | ConvertFrom-Toml` work as people would expect
+
 ## v0.1.0 - 2023-05-22
 
 + Initial version of the `PSToml` module

--- a/docs/en-US/ConvertFrom-Toml.md
+++ b/docs/en-US/ConvertFrom-Toml.md
@@ -34,6 +34,13 @@ PS C:\> $obj.foo  # bar
 Converts the TOML string to a Dictionary object.
 The TOML keys can be accessed in the dictionary like any other dictionary object in PowerShell.
 
+### Example 2 - Convert TOML from file to an object
+```powershell
+PS C:\> Get-Content pyproject.toml | ConvertFrom-Toml
+```
+
+Reads the contents of the file `pyproject.toml` and converts it from the TOML string to an object.
+
 ## PARAMETERS
 
 ### -InputObject
@@ -57,7 +64,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String[]
-Any string piped into this cmdlet will be converted to their own `OrderedDictionary` object.
+All the string inputs will be combined together as a single string to convert from a TOML string.
 
 ## OUTPUTS
 

--- a/module/PSToml.psd1
+++ b/module/PSToml.psd1
@@ -14,7 +14,7 @@
     RootModule = 'bin/net6.0/PSToml.dll'
 
     # Version number of this module.
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/tests/ConvertFrom-Toml.Tests.ps1
+++ b/tests/ConvertFrom-Toml.Tests.ps1
@@ -5,7 +5,13 @@ Describe "ConvertFrom-Toml" {
         $actual = ConvertFrom-Toml -InputObject 'foo' -ErrorAction SilentlyContinue -ErrorVariable err
         $actual | Should -BeNullOrEmpty
         $err.Count | Should -Be 1
-        [string]$err[0] | Should -BeLike '*Expecting ``=`` after a key instead of <eof>*'
+        [string]$err[0] | Should -BeLike '*Expecting ``=`` after a key instead of*'
+    }
+
+    It "Converts multiple input values into 1 toml object" {
+        $actual = "", "foo = 'bar'`n", "`n", "", "hello = 123`r`n", "`r`n" | ConvertFrom-Toml
+        $actual.foo | Should -Be bar
+        $actual.hello | Should -Be 123
     }
 
     It "Converts string type - <Scenario>" -TestCases @(


### PR DESCRIPTION
Changes the piped input behaviour of ConvertFrom-Toml to build a final string to convert from the TOML string. This matches the behaviour of ConvertFrom-Json and makes it easier to do `Get-Content $path | ConvertFrom-Toml`.

Fixes: https://github.com/jborean93/PSToml/issues/1