### PR TITLE
Handle more integer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for PSToml
 
+## v0.5.0 - TBD
+
++ Serializes `UInt64` values that are larger than `Int64.MaxValue` as a string
+  + Toml only supports a 64-bit signed integer so Tomlyn would auto cast to a `Int64` changing the result to a negative number
++ Ensure depth stringification uses the PowerShell string casting behaviour
++ Support `BigInteger` and `Int128`/`UInt128` (PowerShell 7+)
+  + Values that fit within a `Int64` will be serialized as an integer while anything beyond the range will become a string
+
 ## v0.4.0 - 2025-03-12
 
 + Raise minimum PowerShell 7.x version to 7.4

--- a/module/PSToml.psd1
+++ b/module/PSToml.psd1
@@ -14,7 +14,7 @@
     RootModule = 'PSToml.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.4.0'
+    ModuleVersion = '0.5.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSToml/ConvertFromToml.cs
+++ b/src/PSToml/ConvertFromToml.cs
@@ -81,7 +81,6 @@ public sealed class ConvertFromTomlCommand : PSCmdlet
             {
                 TomlArray a => ConvertToArray(a),
                 TomlTable t => ConvertToOrderedDictionary(t),
-                TomlTableArray ta => ConvertToListOfOrderedDictionary(ta),
                 TomlDateTime dt => dt.DateTime,
                 _ => value,
             };

--- a/tests/ConvertFrom-Toml.Tests.ps1
+++ b/tests/ConvertFrom-Toml.Tests.ps1
@@ -233,4 +233,25 @@ bar = []
         ,$actual.features.bar | Should -BeOfType ([object[]])
         $actual.features.bar.Count | Should -Be 0
     }
+
+    It "Converts array with DateTime value" {
+        $actual = ConvertFrom-Toml -InputObject @'
+key = ["1979-05-27T07:32:00-08:00", 1979-05-27T07:32:00-08:00]
+'@
+
+        ,$actual.key | Should -BeOfType ([object[]])
+        $actual.key.Count | Should -Be 2
+
+        $actual.key[0] | Should -BeOfType ([string])
+        $actual.key[0] | Should -Be "1979-05-27T07:32:00-08:00"
+
+        $actual.key[1] | Should -BeOfType ([DateTimeOffset])
+        $actual.key[1].Year | Should -Be 1979
+        $actual.key[1].Month | Should -Be 5
+        $actual.key[1].Day | Should -Be 27
+        $actual.key[1].Hour | Should -Be 7
+        $actual.key[1].Minute | Should -Be 32
+        $actual.key[1].Second | Should -Be 0
+        $actual.key[1].Offset.TotalHours | Should -Be -8
+    }
 }


### PR DESCRIPTION
Add support for more integer types like BigInteger and Int128/UInt128. Also slightly changes the serialization behaviour of a UInt64 that is larger than Int64.MaxValue to be serialized as a string to avoid casting the value to the signed variant.

Changes the string casting behaviour to use PowerShell's ETS which supports more complex string conversions than just ToString().