### PR TITLE
Update Tomlyn to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for PSToml
 
+## v0.6.0 - TBD
+
++ Updated `Tomlyn` to `2.3.0`
+  + This may affect `ConvertTo-Toml` and how it serializes certain types
+
 ## v0.5.0 - 2026-04-02
 
 + Serializes `UInt64` values that are larger than `Int64.MaxValue` as a string

--- a/module/PSToml.psd1
+++ b/module/PSToml.psd1
@@ -14,7 +14,7 @@
     RootModule = 'PSToml.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.5.0'
+    ModuleVersion = '0.6.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSToml/ConvertFromToml.cs
+++ b/src/PSToml/ConvertFromToml.cs
@@ -37,7 +37,7 @@ public sealed class ConvertFromTomlCommand : PSCmdlet
         TomlTable table;
         try
         {
-            table = Toml.ToModel(toml);
+            table = TomlSerializer.Deserialize<TomlTable>(toml)!;
         }
         catch (Exception e)
         {
@@ -64,7 +64,7 @@ public sealed class ConvertFromTomlCommand : PSCmdlet
                 TomlArray a => ConvertToArray(a),
                 TomlTable t => ConvertToOrderedDictionary(t),
                 TomlTableArray ta => ConvertToListOfOrderedDictionary(ta),
-                TomlDateTime dt => dt.DateTime,
+                TomlDateTime dt => ConvertToDateTime(dt),
                 _ => kvp.Value,
             };
         }
@@ -81,7 +81,7 @@ public sealed class ConvertFromTomlCommand : PSCmdlet
             {
                 TomlArray a => ConvertToArray(a),
                 TomlTable t => ConvertToOrderedDictionary(t),
-                TomlDateTime dt => dt.DateTime,
+                TomlDateTime dt => ConvertToDateTime(dt),
                 _ => value,
             };
             result.Add(newValue);
@@ -99,5 +99,23 @@ public sealed class ConvertFromTomlCommand : PSCmdlet
         }
 
         return result.ToArray();
+    }
+
+    private DateTimeOffset ConvertToDateTime(TomlDateTime dt)
+    {
+        // In Tomlyn 1.x+, local datetimes (without timezone) are returned as
+        // UTC. We need to convert them to the local timezone to maintain
+        // backwards compatibility with previous versions of PSToml.
+        if (
+            dt.Kind == TomlDateTimeKind.LocalDateTime ||
+            dt.Kind == TomlDateTimeKind.LocalDate ||
+            dt.Kind == TomlDateTimeKind.LocalTime
+        ) {
+            // Convert from UTC to local time, preserving the date/time components
+            var localOffset = DateTimeOffset.Now.Offset;
+            return new DateTimeOffset(dt.DateTime.DateTime, localOffset);
+        }
+
+        return dt.DateTime;
     }
 }

--- a/src/PSToml/ConvertToToml.cs
+++ b/src/PSToml/ConvertToToml.cs
@@ -35,7 +35,7 @@ public sealed class ConvertToTomlCommand : PSCmdlet
                 TomlTable model = converter.ConvertToToml(input);
                 wasTruncated = converter.WasTruncated;
 
-                res = Toml.FromModel(model);
+                res = TomlSerializer.Serialize(model);
             }
             catch (Exception e)
             {

--- a/src/PSToml/PSToml.csproj
+++ b/src/PSToml/PSToml.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tomlyn" Version="0.19.0" />
+    <PackageReference Include="Tomlyn" Version="2.3.0" />
     <ProjectReference Include="../PSToml.Shared/PSToml.Shared.csproj" />
   </ItemGroup>
 

--- a/tests/ConvertFrom-Toml.Tests.ps1
+++ b/tests/ConvertFrom-Toml.Tests.ps1
@@ -5,7 +5,7 @@ Describe "ConvertFrom-Toml" {
         $actual = ConvertFrom-Toml -InputObject 'foo' -ErrorAction SilentlyContinue -ErrorVariable err
         $actual | Should -BeNullOrEmpty
         $err.Count | Should -Be 1
-        [string]$err[0] | Should -BeLike '*Expecting ``=`` after a key instead of*'
+        [string]$err[0] | Should -BeLike '*Expected ``=`` after key*'
     }
 
     It "Converts multiple input values into 1 toml object" {

--- a/tests/ConvertTo-Toml.Tests.ps1
+++ b/tests/ConvertTo-Toml.Tests.ps1
@@ -62,8 +62,10 @@ color = "red"
 shape = "round"
 [[fruits.varieties]]
 name = "red delicious"
+
 [[fruits.varieties]]
 name = "granny smith"
+
 [[fruits]]
 name = "banana"
 [[fruits.varieties]]


### PR DESCRIPTION
Updates Tomlyn to `2.3.0` which is the latest version. This is a major version update and while tests in this repo show there are very little changes to the serialized format there could be unknown differences in behaviour between the old and new.